### PR TITLE
new 'userWardenAddress' arg in stake methods

### DIFF
--- a/contracts/AaveYield.sol
+++ b/contracts/AaveYield.sol
@@ -18,9 +18,10 @@ contract AaveYield is UUPSUpgradeable, Ownable2StepUpgradeable, AaveInteractor, 
 
   function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-  function stake(address token, uint256 amount) external returns (uint256 shares) {
+  function stake(address token, uint256 amount, string calldata userWardenAddress) external returns (uint256 shares) {
     shares = _stake(token, amount);
     _addStake(msg.sender, token, amount, shares);
+    _addWardenAddress(msg.sender, userWardenAddress);
 
     emit Stake(msg.sender, token, amount, shares);
   }

--- a/contracts/EthYield.sol
+++ b/contracts/EthYield.sol
@@ -33,11 +33,12 @@ contract EthYield is
 
   function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-  function stake(uint256 amount) external payable returns (uint256 eigenLayerShares) {
+  function stake(uint256 amount, string calldata userWardenAddress) external payable returns (uint256 eigenLayerShares) {
     uint256 lidoShares = _lidoStake(amount);
     eigenLayerShares = _eigenLayerRestake(lidoShares);
     address weth = getWeth();
     _addStake(msg.sender, weth, amount, eigenLayerShares);
+    _addWardenAddress(msg.sender, userWardenAddress);
     emit Stake(msg.sender, weth, amount, eigenLayerShares);
   }
 }

--- a/contracts/EthYield.sol
+++ b/contracts/EthYield.sol
@@ -33,7 +33,10 @@ contract EthYield is
 
   function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
-  function stake(uint256 amount, string calldata userWardenAddress) external payable returns (uint256 eigenLayerShares) {
+  function stake(
+    uint256 amount,
+    string calldata userWardenAddress
+  ) external payable returns (uint256 eigenLayerShares) {
     uint256 lidoShares = _lidoStake(amount);
     eigenLayerShares = _eigenLayerRestake(lidoShares);
     address weth = getWeth();

--- a/contracts/YieldStorage.sol
+++ b/contracts/YieldStorage.sol
@@ -1,13 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity =0.8.26;
 
+import '@openzeppelin/contracts/utils/Strings.sol';
+
+import './libraries/Errors.sol';
+
 abstract contract YieldStorage {
+  using Strings for string;
+
   /// @custom:storage-location erc7201:eq-lab.storage.StakingData
   struct StakingData {
     mapping(address /* token */ => uint256) _totalStakedAmount;
     mapping(address /* token */ => uint256) _totalShares;
     mapping(address /* token */ => mapping(address => uint256)) _stakedAmount;
     mapping(address /* token */ => mapping(address => uint256)) _shares;
+  }
+
+  /// @custom:storage-location erc7201:eq-lab.storage.UserWardenData
+  struct UserWardenData {
     mapping(address /* evmAddress */ => string) _wardenAddress;
   }
 
@@ -15,9 +25,19 @@ abstract contract YieldStorage {
   bytes32 private constant StakingDataStorageLocation =
     0x69b3bfac4ac6bf246ceef7427e431f481bd6bde26467dffa51aa8b49ac672600;
 
+  // keccak256(abi.encode(uint256(keccak256("eq-lab.storage.UserWardenData")) - 1)) & ~bytes32(uint256(0xff))
+  bytes32 private constant UserWardenDataStorageLocation =
+    0x730e2444c52438fad4871347d49b7d0d3be1e25c4cf433da8143e5ca5ac50700;
+
   function _getStakingDataStorage() internal pure returns (StakingData storage $) {
     assembly {
       $.slot := StakingDataStorageLocation
+    }
+  }
+
+  function _getUserWardenDataStorage() internal pure returns (UserWardenData storage $) {
+    assembly {
+      $.slot := UserWardenDataStorageLocation
     }
   }
 
@@ -37,6 +57,17 @@ abstract contract YieldStorage {
 
     $._totalShares[token] -= $._shares[token][user];
     $._shares[token][user] = 0;
+  }
+
+  function _addWardenAddress(address user, string calldata userWardenAddress) internal {
+    UserWardenData storage $ = _getUserWardenDataStorage();
+    string memory currentWardenAddress = $._wardenAddress[user];
+
+    if (bytes(currentWardenAddress).length == 0) {
+      $._wardenAddress[user] = userWardenAddress;
+    } else if (!currentWardenAddress.equal(userWardenAddress)) {
+      revert Errors.WrongWardenAddress(user, currentWardenAddress, userWardenAddress);
+    }
   }
 
   function totalShares(address token) public view returns (uint256) {
@@ -60,7 +91,7 @@ abstract contract YieldStorage {
   }
 
   function wardenAddress(address user) public view returns (string memory) {
-    StakingData storage $ = _getStakingDataStorage();
+    UserWardenData storage $ = _getUserWardenDataStorage();
     return $._wardenAddress[user];
   }
 }

--- a/contracts/YieldStorage.sol
+++ b/contracts/YieldStorage.sol
@@ -21,6 +21,8 @@ abstract contract YieldStorage {
     mapping(address /* evmAddress */ => string) _wardenAddress;
   }
 
+  event WardenAddressSet(address indexed evmAddress, string indexed wardenAddress);
+
   // keccak256(abi.encode(uint256(keccak256("eq-lab.storage.StakingData")) - 1)) & ~bytes32(uint256(0xff))
   bytes32 private constant StakingDataStorageLocation =
     0x69b3bfac4ac6bf246ceef7427e431f481bd6bde26467dffa51aa8b49ac672600;
@@ -65,6 +67,7 @@ abstract contract YieldStorage {
 
     if (bytes(currentWardenAddress).length == 0) {
       $._wardenAddress[user] = userWardenAddress;
+      emit WardenAddressSet(user, userWardenAddress);
     } else if (!currentWardenAddress.equal(userWardenAddress)) {
       revert Errors.WrongWardenAddress(user, currentWardenAddress, userWardenAddress);
     }

--- a/contracts/interfaces/IAaveYield.sol
+++ b/contracts/interfaces/IAaveYield.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.26;
 import './IYieldBase.sol';
 
 interface IAaveYield is IYieldBase {
-  function stake(address token, uint256 amount) external returns (uint256);
+  function stake(address token, uint256 amount, string calldata wardenAddress) external returns (uint256);
   function withdraw(address token) external returns (uint256 withdrawAmount);
   function getAvailableToWithdraw(address user, address token) external view returns (uint256 availableToWithdraw);
 }

--- a/contracts/interfaces/IEthYield.sol
+++ b/contracts/interfaces/IEthYield.sol
@@ -4,5 +4,5 @@ pragma solidity =0.8.26;
 import './IYieldBase.sol';
 
 interface IEthYield is IYieldBase {
-  function stake(uint256 amount) external payable returns (uint256);
+  function stake(uint256 amount, string calldata wardenAddress) external payable returns (uint256);
 }

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -14,4 +14,5 @@ library Errors {
   error WrongStrategy(address);
   error WrongOperator(address);
   error NotWETH9(address);
+  error WrongWardenAddress(address user, string currentWardenAddress, string passedWardenAddress);
 }

--- a/contracts/test/TestYieldStorage.sol
+++ b/contracts/test/TestYieldStorage.sol
@@ -24,6 +24,10 @@ contract TestYieldStorage is UUPSUpgradeable, Ownable2StepUpgradeable, YieldStor
     _addStake(msg.sender, WETH9, amount, stakedAmount);
   }
 
+  function addWardenAddress(string calldata userWardenAddress) external {
+    _addWardenAddress(msg.sender, userWardenAddress);
+  }
+
   function getStakedAmount(uint256 amount) public pure returns (uint256) {
     return (amount * STAKING_RATIO) / ONE;
   }

--- a/test/Stake.spec.ts
+++ b/test/Stake.spec.ts
@@ -3,6 +3,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { ethers } from 'hardhat';
 import { parseUnits } from 'ethers';
 import { testYieldStorageFixture } from './shared/fixtures';
+import { USER_WARDEN_ADDRESS } from './shared/utils';
 
 describe('Staking', () => {
   it('stake', async () => {
@@ -18,5 +19,35 @@ describe('Staking', () => {
     expect(await testYieldStorage.userShares(user.address, weth9Address)).to.be.eq(shares);
     expect(await testYieldStorage.totalStakedAmount(weth9Address)).to.be.eq(stakeAmount);
     expect(await testYieldStorage.totalShares(weth9Address)).to.be.eq(shares);
+  });
+});
+
+describe('AddWardenAddress', () => {
+  it('add new warden address', async () => {
+    const { testYieldStorage } = await loadFixture(testYieldStorageFixture);
+    const [_, user] = await ethers.getSigners();
+
+    await testYieldStorage.connect(user).addWardenAddress(USER_WARDEN_ADDRESS);
+    expect(await testYieldStorage.wardenAddress(user.address)).to.be.eq(USER_WARDEN_ADDRESS);
+  });
+
+  it('passing the same address after setting', async () => {
+    const { testYieldStorage } = await loadFixture(testYieldStorageFixture);
+    const [_, user] = await ethers.getSigners();
+
+    await testYieldStorage.connect(user).addWardenAddress(USER_WARDEN_ADDRESS);
+    await testYieldStorage.connect(user).addWardenAddress(USER_WARDEN_ADDRESS);
+    expect(await testYieldStorage.wardenAddress(user.address)).to.be.eq(USER_WARDEN_ADDRESS);
+  });
+
+  it('passing another address after setting', async () => {
+    const { testYieldStorage } = await loadFixture(testYieldStorageFixture);
+    const [_, user] = await ethers.getSigners();
+
+    await testYieldStorage.connect(user).addWardenAddress(USER_WARDEN_ADDRESS);
+    await expect(testYieldStorage.connect(user).addWardenAddress('warden1233')).to.be.revertedWithCustomError(
+      testYieldStorage,
+      'WrongWardenAddress'
+    );
   });
 });

--- a/test/int/Aave.spec.ts
+++ b/test/int/Aave.spec.ts
@@ -4,7 +4,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { ethers } from 'hardhat';
 import { parseEther } from 'ethers';
 import { createAaveEthFork } from '../shared/fixtures';
-import { setTokenBalance } from '../shared/utils';
+import { USER_WARDEN_ADDRESS, setTokenBalance } from '../shared/utils';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { AaveYield, ERC20, IAToken, IERC20 } from '../../typechain-types';
 
@@ -49,7 +49,7 @@ async function stake(
   // approve WETH before stake
   await weth9.connect(signer).approve(aaveYieldAddress, amount);
   // stake
-  await aaveYield.connect(signer).stake(weth9Address, amount);
+  await aaveYield.connect(signer).stake(weth9Address, amount, USER_WARDEN_ADDRESS);
 
   // check balances
   expect(await weth9.balanceOf(signer.address)).to.be.eq(0);

--- a/test/int/Aave.spec.ts
+++ b/test/int/Aave.spec.ts
@@ -37,7 +37,8 @@ async function stake(
   signer: HardhatEthersSigner,
   aEthWETH: IAToken,
   weth9: ERC20,
-  amount: bigint
+  amount: bigint,
+  userWardenAddress: string
 ): Promise<void> {
   const aaveYieldAddress = await aaveYield.getAddress();
   const weth9Address = await weth9.getAddress();
@@ -49,7 +50,7 @@ async function stake(
   // approve WETH before stake
   await weth9.connect(signer).approve(aaveYieldAddress, amount);
   // stake
-  await aaveYield.connect(signer).stake(weth9Address, amount, USER_WARDEN_ADDRESS);
+  await aaveYield.connect(signer).stake(weth9Address, amount, userWardenAddress);
 
   // check balances
   expect(await weth9.balanceOf(signer.address)).to.be.eq(0);
@@ -110,13 +111,15 @@ describe('AaveYield', () => {
     console.log(`User init balance: ${ethers.formatEther(userInput)} WETH`);
 
     console.log(`User stake`);
-    await stake(aaveYield, user, aEthWETH, weth9, userInput);
+    await stake(aaveYield, user, aEthWETH, weth9, userInput, USER_WARDEN_ADDRESS);
 
     console.log(`User withdraw`);
     await withdraw(aaveYield, user, aEthWETH, weth9);
 
     expect(await aaveYield.totalStakedAmount(weth9Address)).to.be.eq(0);
     expect(await aaveYield.totalShares(weth9Address)).to.be.eq(0);
+
+    expect(await aaveYield.wardenAddress(user.address)).to.be.eq(USER_WARDEN_ADDRESS);
   });
 
   it('2 users: stake & unstake', async () => {
@@ -128,17 +131,18 @@ describe('AaveYield', () => {
 
     // init balances
     const user1Input = await initBalance(user1.address, weth9, '1');
+    const user1WardenAddress = USER_WARDEN_ADDRESS;
     console.log(`User1 init balance: ${ethers.formatEther(user1Input)} WETH`);
 
     const user2Input = await initBalance(user2.address, weth9, '2');
+    const user2WardenAddress = 'warden1233';
     console.log(`User2 init balance: ${ethers.formatEther(user2Input)} WETH`);
 
     console.log(`User1 stake`);
-    await stake(aaveYield, user1, aEthWETH, weth9, user1Input);
+    await stake(aaveYield, user1, aEthWETH, weth9, user1Input, user1WardenAddress);
 
     console.log(`User2 stake`);
-    await stake(aaveYield, user2, aEthWETH, weth9, user2Input);
-
+    await stake(aaveYield, user2, aEthWETH, weth9, user2Input, user2WardenAddress);
     console.log(`User1 withdraw`);
     await withdraw(aaveYield, user1, aEthWETH, weth9);
 
@@ -147,5 +151,8 @@ describe('AaveYield', () => {
 
     expect(await aaveYield.totalStakedAmount(weth9Address)).to.be.eq(0);
     expect(await aaveYield.totalShares(weth9Address)).to.be.eq(0);
+
+    expect(await aaveYield.wardenAddress(user1.address)).to.be.eq(user1WardenAddress);
+    expect(await aaveYield.wardenAddress(user2.address)).to.be.eq(user2WardenAddress);
   });
 });

--- a/test/int/EthYield.spec.ts
+++ b/test/int/EthYield.spec.ts
@@ -30,6 +30,8 @@ describe('EthYield', () => {
     const contractShares = await eigenLayerStrategy.shares(EthYield.target);
     expect(contractShares).to.be.eq(await EthYield.totalShares(weth9.target));
 
+    expect(await EthYield.wardenAddress(user.address)).to.be.eq(USER_WARDEN_ADDRESS);
+
     const [event] = await eigenLayerDelegationManager.queryFilter(filter, -1);
     expect(event.args[0]).to.be.eq(eigenLayerOperator);
     expect(event.args[1]).to.be.eq(EthYield.target);
@@ -61,6 +63,8 @@ describe('EthYield', () => {
 
     const contractShares = await eigenLayerStrategy.shares(EthYield.target);
     expect(contractShares).to.be.eq(await EthYield.totalShares(weth9.target));
+
+    expect(await EthYield.wardenAddress(user.address)).to.be.eq(USER_WARDEN_ADDRESS);
 
     const [event] = await eigenLayerDelegationManager.queryFilter(filter, -1);
     expect(event.args[0]).to.be.eq(eigenLayerOperator);

--- a/test/int/EthYield.spec.ts
+++ b/test/int/EthYield.spec.ts
@@ -4,7 +4,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { createEthYieldFork, deployEthYieldContract } from '../shared/fixtures';
 import { ethers } from 'hardhat';
 import { parseEther } from 'ethers';
-import { EthAddressData, setTokenBalance } from '../shared/utils';
+import { EthAddressData, USER_WARDEN_ADDRESS, setTokenBalance } from '../shared/utils';
 import { EthYield__factory } from '../../typechain-types';
 
 describe('EthYield', () => {
@@ -19,7 +19,7 @@ describe('EthYield', () => {
     const filter = eigenLayerDelegationManager.filters.OperatorSharesIncreased;
 
     const input = parseEther('1');
-    await EthYield.connect(user).stake(input, { value: input });
+    await EthYield.connect(user).stake(input, USER_WARDEN_ADDRESS, { value: input });
 
     expect(await EthYield.totalStakedAmount(weth9.target)).to.be.eq(input);
     expect(await EthYield.userStakedAmount(user.address, weth9.target)).to.be.eq(input);
@@ -51,7 +51,7 @@ describe('EthYield', () => {
     const userWethBalanceBefore = await weth9.balanceOf(user.address);
     await weth9.connect(user).approve(EthYield.target, input);
 
-    await EthYield.connect(user).stake(input);
+    await EthYield.connect(user).stake(input, USER_WARDEN_ADDRESS);
 
     expect(await EthYield.totalStakedAmount(weth9.target)).to.be.eq(input);
     expect(await EthYield.userStakedAmount(user.address, weth9.target)).to.be.eq(input);
@@ -76,7 +76,7 @@ describe('EthYield', () => {
     const [_, user] = await ethers.getSigners();
 
     const input = parseEther('1');
-    await expect(EthYield.connect(user).stake(input, { value: input - 1n })).to.be.revertedWithCustomError(
+    await expect(EthYield.connect(user).stake(input, USER_WARDEN_ADDRESS, { value: input - 1n })).to.be.revertedWithCustomError(
       EthYield,
       'WrongMsgValue'
     );

--- a/test/int/EthYield.spec.ts
+++ b/test/int/EthYield.spec.ts
@@ -76,10 +76,9 @@ describe('EthYield', () => {
     const [_, user] = await ethers.getSigners();
 
     const input = parseEther('1');
-    await expect(EthYield.connect(user).stake(input, USER_WARDEN_ADDRESS, { value: input - 1n })).to.be.revertedWithCustomError(
-      EthYield,
-      'WrongMsgValue'
-    );
+    await expect(
+      EthYield.connect(user).stake(input, USER_WARDEN_ADDRESS, { value: input - 1n })
+    ).to.be.revertedWithCustomError(EthYield, 'WrongMsgValue');
   });
 });
 

--- a/test/shared/utils.ts
+++ b/test/shared/utils.ts
@@ -1,5 +1,7 @@
 import { ethers } from 'hardhat';
 
+export const USER_WARDEN_ADDRESS = 'warden1234';
+
 export enum EthAddressData {
   weth = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
   stEth = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing user warden addresses in staking functions.
  - Users can now associate a warden address when staking tokens.

- **Bug Fixes**
  - Address validation logic for user warden addresses has been improved.

- **Tests**
  - Added test cases to verify the addition and validation of warden addresses.
  - Updated existing tests to include the new `userWardenAddress` parameter.
  
- **Documentation**
  - Updated function signatures and descriptions to reflect new warden address parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->