### PR TITLE
fix wrong stEth restaking amount

### DIFF
--- a/contracts/EthYield.sol
+++ b/contracts/EthYield.sol
@@ -37,8 +37,8 @@ contract EthYield is
     uint256 amount,
     string calldata userWardenAddress
   ) external payable returns (uint256 eigenLayerShares) {
-    uint256 lidoShares = _lidoStake(amount);
-    eigenLayerShares = _eigenLayerRestake(lidoShares);
+    uint256 stEthAmount = _lidoStake(amount);
+    eigenLayerShares = _eigenLayerRestake(stEthAmount);
     address weth = getWeth();
     _addStake(msg.sender, weth, amount, eigenLayerShares);
     _addWardenAddress(msg.sender, userWardenAddress);

--- a/contracts/interactors/LidoInteractor.sol
+++ b/contracts/interactors/LidoInteractor.sol
@@ -2,6 +2,7 @@
 pragma solidity =0.8.26;
 
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '@openzeppelin/contracts/utils/math/Math.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 
 import '../libraries/Errors.sol';
@@ -38,7 +39,7 @@ abstract contract LidoInteractor is Initializable {
     $.wETH9 = wETH9;
   }
 
-  function _lidoStake(uint256 ethAmount) internal returns (uint256 stEthStakedAmount) {
+  function _lidoStake(uint256 ethAmount) internal returns (uint256 stEthAmount) {
     if (ethAmount == 0) revert Errors.ZeroAmount();
     LidoInteractorData memory data = _getLidoInteractorDataStorage();
 
@@ -49,7 +50,8 @@ abstract contract LidoInteractor is Initializable {
       revert Errors.WrongMsgValue(msg.value, ethAmount);
     }
 
-    stEthStakedAmount = IStETH(data.stETH).submit{value: ethAmount}(address(0));
+    uint256 lidoShares = IStETH(data.stETH).submit{value: ethAmount}(address(0));
+    stEthAmount = IStETH(data.stETH).getPooledEthByShares(lidoShares);
   }
 
   function getWeth() public view returns (address) {

--- a/contracts/interfaces/Lido/IStETH.sol
+++ b/contracts/interfaces/Lido/IStETH.sol
@@ -6,4 +6,6 @@ import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 /// @title Interface for StETH
 interface IStETH is IERC20 {
   function submit(address referral) external payable returns (uint256);
+
+  function getPooledEthByShares(uint256 _sharesAmount) external view returns (uint256);
 }

--- a/test/int/EthYield.spec.ts
+++ b/test/int/EthYield.spec.ts
@@ -9,7 +9,7 @@ import { EthYield__factory } from '../../typechain-types';
 
 describe('EthYield', () => {
   it('user stake, native', async () => {
-    const { eigenLayerDelegationManager, eigenLayerOperator, eigenLayerStrategy, EthYield, weth9 } =
+    const { eigenLayerDelegationManager, eigenLayerOperator, eigenLayerStrategy, EthYield, weth9, stEth } =
       await loadFixture(createEthYieldFork);
     // set up during EthYield contract init
     expect(await eigenLayerDelegationManager.delegatedTo(EthYield.target)).to.be.eq(eigenLayerOperator);
@@ -37,10 +37,12 @@ describe('EthYield', () => {
     expect(event.args[1]).to.be.eq(EthYield.target);
     expect(event.args[2]).to.be.eq(eigenLayerStrategy.target);
     expect(event.args[3]).to.be.eq(contractShares);
+
+    expect(await stEth.balanceOf(EthYield.target)).to.be.lessThanOrEqual(1);
   });
 
   it('user stake, weth', async () => {
-    const { eigenLayerStrategy, eigenLayerDelegationManager, eigenLayerOperator, weth9, EthYield } =
+    const { eigenLayerStrategy, eigenLayerDelegationManager, eigenLayerOperator, weth9, EthYield, stEth } =
       await loadFixture(createEthYieldFork);
     // set up during EthYield contract init
     expect(await eigenLayerDelegationManager.delegatedTo(EthYield.target)).to.be.eq(eigenLayerOperator);
@@ -71,6 +73,8 @@ describe('EthYield', () => {
     expect(event.args[1]).to.be.eq(EthYield.target);
     expect(event.args[2]).to.be.eq(eigenLayerStrategy.target);
     expect(event.args[3]).to.be.eq(contractShares);
+
+    expect(await stEth.balanceOf(EthYield.target)).to.be.lessThanOrEqual(1);
   });
 
   it('user stake, wrong msg.value', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a function to retrieve the amount of pooled ETH corresponding to a given shares amount.
- **Refactor**
	- Renamed variables for clarity in contract and test files, ensuring consistent terminology.
- **Tests**
	- Updated test cases to include new variable and added assertions for `stEth` balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->