### PR TITLE
Fix CosmWasm contract, update tests

### DIFF
--- a/cosmwasm/README.md
+++ b/cosmwasm/README.md
@@ -13,7 +13,7 @@
 
 ```bash
 wardend tx wasm store lp_token.wasm \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3 \
@@ -24,7 +24,7 @@ wardend tx wasm store lp_token.wasm \
 
 ```bash
 wardend tx wasm store yield_ward.wasm \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3 \
@@ -58,7 +58,7 @@ wardend tx wasm instantiate 9 \
   '{"name":"Ethereum","symbol":"ETH","decimals":18,"initial_balances":[],"mint":{"minter":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl"}}' \
   --label "ETH-demo-2024-08-29" \
   --admin "warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl" \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1"
 
@@ -66,7 +66,7 @@ wardend tx wasm instantiate 9 \
   '{"name":"Tether USD","symbol":"USDT","decimals":6,"initial_balances":[],"mint":{"minter":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl"}}' \
   --label "USDT-demo-2024-08-29" \
   --admin "warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl" \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1"
 
@@ -74,7 +74,7 @@ wardend tx wasm instantiate 9 \
   '{"name":"Circle USD","symbol":"USDC","decimals":6,"initial_balances":[],"mint":{"minter":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl"}}' \
   --label "USDC-demo-2024-08-29" \
   --admin "warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl" \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1"
 ```
@@ -103,7 +103,7 @@ WETH:
 wardend tx wasm execute \
   warden1vhjnzk9ly03dugffvzfcwgry4dgc8x0sv0nqqtfxj3ajn7rn5ghq6xwfv9 \
   '{"add_token":{"token_denom":"demo_weth","cw20_address":"warden1dk9c86h7gmvuaq89cv72cjhq4c97r2wgl5gyfruv6shquwspalgqr09xey","is_stake_enabled":true,"is_unstake_enabled":true,"chain":"Ethereum","lpt_symbol":"LPWETH","lpt_name":"Wrapped Ether LPT","evm_yield_contract":"0x4DF66BCA96319C6A033cfd86c38BCDb9B3c11a72","evm_address":"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2","lp_token_denom":"demo_weth_lp"}}' \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3
@@ -115,7 +115,7 @@ USDT:
 wardend tx wasm execute \
   warden1vhjnzk9ly03dugffvzfcwgry4dgc8x0sv0nqqtfxj3ajn7rn5ghq6xwfv9 \
   '{"add_token":{"token_denom":"demo_usdt","cw20_address":"warden1xqkp8x4gqwjnhemtemc5dqhwll6w6rrgpywvhka7sh8vz8swul9ss7ztuk","is_stake_enabled":true,"is_unstake_enabled":true,"chain":"Ethereum","lpt_symbol":"LPUSDT","lpt_name":"Tether USD LPT","evm_yield_contract":"0x0F9d2C03AD21a30746A4b4f07919e1C5F3641F35","evm_address":"0xdAC17F958D2ee523a2206206994597C13D831ec7","lp_token_denom":"demo_usdt_lp"}}' \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3
@@ -127,7 +127,7 @@ USDC:
 wardend tx wasm execute \
   warden1vhjnzk9ly03dugffvzfcwgry4dgc8x0sv0nqqtfxj3ajn7rn5ghq6xwfv9 \
   '{"add_token":{"token_denom":"demo_usdc","cw20_address":"warden1euqmngymytlt8j707spv9hn6ajzy92ndfjk47pnlu9uzmfuyplhsyeh0vc","is_stake_enabled":true,"is_unstake_enabled":true,"chain":"Ethereum","lpt_symbol":"LPUSDC","lpt_name":"Circle USD LPT","evm_yield_contract":"0x0259044395FE54d8aFe28354Ac737EB216064cF9","evm_address":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","lp_token_denom":"demo_usdc_lp"}}' \
-  --from "keplr_test2_acc" -y \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3
@@ -140,8 +140,8 @@ ETH:
 ```bash  
 wardend tx wasm execute \
   warden1dk9c86h7gmvuaq89cv72cjhq4c97r2wgl5gyfruv6shquwspalgqr09xey \
-  '{"mint":{"recipient":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl","amount":"1000000000000000000"}}' \
-  --from "keplr_test2_acc" -y \
+  '{"mint":{"recipient":"warden1730hj2t4dycp7aa2uv63gsuuhrnc5x50x70wkf","amount":"100000000000000000"}}' \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3
@@ -152,8 +152,8 @@ USDT:
 ```bash  
 wardend tx wasm execute \
   warden1xqkp8x4gqwjnhemtemc5dqhwll6w6rrgpywvhka7sh8vz8swul9ss7ztuk \
-  '{"mint":{"recipient":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl","amount":"1000000000"}}' \
-  --from "keplr_test2_acc" -y \
+  '{"mint":{"recipient":"warden1730hj2t4dycp7aa2uv63gsuuhrnc5x50x70wkf","amount":"1000000000"}}' \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3
@@ -164,8 +164,8 @@ USDC:
 ```bash  
 wardend tx wasm execute \
   warden1euqmngymytlt8j707spv9hn6ajzy92ndfjk47pnlu9uzmfuyplhsyeh0vc \
-  '{"mint":{"recipient":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl","amount":"1000000000"}}' \
-  --from "keplr_test2_acc" -y \
+  '{"mint":{"recipient":"warden1mscv9y928gq6ankczrwr8mgt2fc6matv0086dy","amount":"1000000000"}}' \
+  --from "yieldward-stage-admin" -y \
   --node "https://rpc.buenavista.wardenprotocol.org:443" \
   --chain-id "buenavista-1" \
   --gas auto --gas-adjustment 1.3
@@ -175,8 +175,8 @@ wardend tx wasm execute \
 
 ```bash
 wardend query wasm contract-state smart \
-  warden1euqmngymytlt8j707spv9hn6ajzy92ndfjk47pnlu9uzmfuyplhsyeh0vc \
-  '{"balance":{"address":"warden1ptf722r8tnxk8c7w5twln6xxp9hzc2fzr5djkl"}}' \
+  warden1dk9c86h7gmvuaq89cv72cjhq4c97r2wgl5gyfruv6shquwspalgqr09xey \
+  '{"balance":{"address":"warden1mscv9y928gq6ankczrwr8mgt2fc6matv0086dy"}}' \
   --node "https://rpc.buenavista.wardenprotocol.org:443"
 ```
 

--- a/cosmwasm/contracts/yield-ward/src/contract.rs
+++ b/cosmwasm/contracts/yield-ward/src/contract.rs
@@ -13,8 +13,8 @@ use crate::execute::receive_cw20::try_receive_cw20;
 use crate::execute::reinit::try_reinit;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::query::{
-    query_contract_config, query_stake_item, query_stake_params, query_stake_stats,
-    query_tokens_configs, query_unstake_item, query_unstake_params,
+    query_all_tokens_denoms_by_source, query_contract_config, query_stake_item, query_stake_params,
+    query_stake_stats, query_tokens_configs, query_unstake_item, query_unstake_params,
 };
 use crate::reply::handle_lp_token_mint_reply;
 use crate::state::{ContractConfigState, CONTRACT_CONFIG};
@@ -124,6 +124,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::UnstakeElem { token_denom, id } => {
             to_json_binary(&query_unstake_item(deps, token_denom, id)?)
+        }
+        QueryMsg::TokenDenomBySource {} => {
+            to_json_binary(&query_all_tokens_denoms_by_source(deps)?)
         }
     }
 }

--- a/cosmwasm/contracts/yield-ward/src/encoding.rs
+++ b/cosmwasm/contracts/yield-ward/src/encoding.rs
@@ -4,9 +4,13 @@ use crate::types::{
 use cosmwasm_std::{Binary, Uint128};
 
 pub fn encode_stake_payload(stake_id: &u64) -> Binary {
-    let payload: Vec<u8> = stake_id
-        .to_be_bytes()
+    // 32 bytes:
+    //    23 bytes - not used
+    //    8 bytes  - StakeId
+    //    1 byte   - ActionType
+    let payload: Vec<u8> = vec![0_u8; 23]
         .into_iter()
+        .chain(stake_id.to_be_bytes().into_iter())
         .chain(Some(0)) // ActionType: stake = 0_u8
         .collect();
 
@@ -15,9 +19,14 @@ pub fn encode_stake_payload(stake_id: &u64) -> Binary {
 }
 
 pub fn encode_unstake_payload(unstake_id: &u64, lp_token_amount: &Uint128) -> Binary {
-    let payload: Vec<u8> = lp_token_amount
-        .to_be_bytes()
+    // 32 bytes:
+    //    7 bytes - not used
+    //    16 bytes - LptAmount
+    //    8 bytes  - UnstakeId
+    //    1 byte   - ActionType
+    let payload: Vec<u8> = vec![0_u8; 7]
         .into_iter()
+        .chain(lp_token_amount.to_be_bytes().into_iter())
         .chain(unstake_id.to_be_bytes().into_iter())
         .chain(Some(1)) // ActionType::Unstake = 1_u8
         .collect();

--- a/cosmwasm/contracts/yield-ward/src/execute/configs.rs
+++ b/cosmwasm/contracts/yield-ward/src/execute/configs.rs
@@ -1,8 +1,8 @@
 use crate::helpers::assert_msg_sender_is_admin;
-use crate::state::{ContractConfigState, CONTRACT_CONFIG, TOKEN_CONFIG};
+use crate::state::{ContractConfigState, CONTRACT_CONFIG, TOKEN_CONFIG, TOKEN_DENOM_BY_SOURCE};
 use crate::types::TokenConfig;
 use crate::ContractError;
-use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
+use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Order, Response, StdResult};
 
 pub fn try_update_token_config(
     deps: DepsMut,
@@ -18,7 +18,33 @@ pub fn try_update_token_config(
     }
     TOKEN_CONFIG.save(deps.storage, &token_denom, &config)?;
 
-    Ok(Response::new().add_event(Event::new("update_token_config")))
+    let tokens_denoms = TOKEN_DENOM_BY_SOURCE
+        .range(deps.storage, None, None, Order::Ascending)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    let (source_chain_old, source_address_old) = tokens_denoms
+        .iter()
+        .find_map(
+            |((source_chain, source_address), td)| match td == &token_denom {
+                true => Some((source_chain.as_str(), source_address.as_str())),
+                false => None,
+            },
+        )
+        .ok_or(ContractError::UnknownToken(token_denom.clone()))?;
+
+    if source_chain_old != config.chain || source_address_old != config.evm_yield_contract {
+        TOKEN_DENOM_BY_SOURCE.remove(deps.storage, (source_chain_old, source_address_old));
+        TOKEN_DENOM_BY_SOURCE.save(
+            deps.storage,
+            (config.chain.as_str(), config.evm_yield_contract.as_str()),
+            &token_denom,
+        )?;
+    }
+
+    Ok(Response::new().add_event(
+        Event::new("update_token_config")
+            .add_attribute("token_symbol", config.deposit_token_symbol),
+    ))
 }
 
 pub fn try_update_contract_config(

--- a/cosmwasm/contracts/yield-ward/src/execute/reinit.rs
+++ b/cosmwasm/contracts/yield-ward/src/execute/reinit.rs
@@ -44,6 +44,11 @@ pub fn handle_reinit(
 
     // update unstake item
     unstake_item.action_stage = UnstakeActionStage::Executed;
+    unstake_item.token_amount = match unstake_item.token_amount {
+        Some(amount) => Some(amount + token_amount),
+        None => Some(token_amount),
+    };
+
     UNSTAKES.save(
         deps.storage,
         (&deposit_token_denom, reinit_unstake_id.clone()),
@@ -71,7 +76,8 @@ pub fn handle_reinit(
         Event::new("unstake_finished")
             .add_attribute("token", deposit_token_denom)
             .add_attribute("lp_amount", unstake_item.lp_token_amount)
-            .add_attribute("token_amount", token_amount),
+            .add_attribute("token_amount", token_amount)
+            .add_attribute("total_token_amount", unstake_item.token_amount.unwrap()),
     ))
 }
 

--- a/cosmwasm/contracts/yield-ward/src/execute/stake.rs
+++ b/cosmwasm/contracts/yield-ward/src/execute/stake.rs
@@ -41,6 +41,7 @@ pub fn try_init_stake(
             user,
             token_amount,
             action_stage: StakeActionStage::WaitingExecution,
+            lp_token_amount: None,
         },
     )?;
 

--- a/cosmwasm/contracts/yield-ward/src/execute/unstake.rs
+++ b/cosmwasm/contracts/yield-ward/src/execute/unstake.rs
@@ -40,6 +40,7 @@ pub fn try_init_unstake(
             user,
             lp_token_amount: lpt_amount,
             action_stage: UnstakeActionStage::WaitingRegistration,
+            token_amount: None,
         },
     )?;
 

--- a/cosmwasm/contracts/yield-ward/src/msg.rs
+++ b/cosmwasm/contracts/yield-ward/src/msg.rs
@@ -68,6 +68,8 @@ pub enum QueryMsg {
     StakeElem { token_denom: TokenDenom, id: u64 },
     #[returns(GetUnstakeItemResponse)]
     UnstakeElem { token_denom: TokenDenom, id: u64 },
+    #[returns(GetTokenDenomBySourceResponse)]
+    TokenDenomBySource {},
 }
 
 #[cw_serde]
@@ -98,6 +100,11 @@ pub struct GetUnstakeItemResponse {
 #[cw_serde]
 pub struct GetQueueParamsResponse {
     pub params: QueueParams,
+}
+
+#[cw_serde]
+pub struct GetTokenDenomBySourceResponse {
+    pub tokens_denoms: Vec<(String, String, TokenDenom)>,
 }
 
 #[cw_serde]

--- a/cosmwasm/contracts/yield-ward/src/query.rs
+++ b/cosmwasm/contracts/yield-ward/src/query.rs
@@ -1,9 +1,10 @@
 use crate::msg::{
     GetContractConfigResponse, GetQueueParamsResponse, GetStakeItemResponse, GetStakeStatsResponse,
-    GetTokensConfigsResponse, GetUnstakeItemResponse,
+    GetTokenDenomBySourceResponse, GetTokensConfigsResponse, GetUnstakeItemResponse,
 };
 use crate::state::{
-    CONTRACT_CONFIG, STAKES, STAKE_PARAMS, STAKE_STATS, TOKEN_CONFIG, UNSTAKES, UNSTAKE_PARAMS,
+    CONTRACT_CONFIG, STAKES, STAKE_PARAMS, STAKE_STATS, TOKEN_CONFIG, TOKEN_DENOM_BY_SOURCE,
+    UNSTAKES, UNSTAKE_PARAMS,
 };
 use crate::types::TokenDenom;
 use cosmwasm_std::{Deps, Order, StdResult};
@@ -69,4 +70,19 @@ pub fn query_unstake_item(
     Ok(GetUnstakeItemResponse {
         item: UNSTAKES.load(deps.storage, (&token_denom, id))?,
     })
+}
+
+pub fn query_all_tokens_denoms_by_source(deps: Deps) -> StdResult<GetTokenDenomBySourceResponse> {
+    let tokens_denoms: StdResult<Vec<_>> = TOKEN_DENOM_BY_SOURCE
+        .range(deps.storage, None, None, Order::Ascending)
+        .collect();
+
+    let tokens_denoms: Vec<_> = tokens_denoms?
+        .into_iter()
+        .map(|((source_chain, source_address), token_denom)| {
+            (source_chain, source_address, token_denom)
+        })
+        .collect();
+
+    Ok(GetTokenDenomBySourceResponse { tokens_denoms })
 }

--- a/cosmwasm/contracts/yield-ward/src/state.rs
+++ b/cosmwasm/contracts/yield-ward/src/state.rs
@@ -41,7 +41,7 @@ pub struct StakeItem {
     pub user: Addr,
     pub token_amount: Uint128,
     pub action_stage: StakeActionStage,
-    // todo: add optional lp amount
+    pub lp_token_amount: Option<Uint128>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -49,7 +49,7 @@ pub struct UnstakeItem {
     pub user: Addr,
     pub lp_token_amount: Uint128,
     pub action_stage: UnstakeActionStage,
-    // todo: add optional underlying amount
+    pub token_amount: Option<Uint128>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/cosmwasm/contracts/yield-ward/src/tests/encoding.rs
+++ b/cosmwasm/contracts/yield-ward/src/tests/encoding.rs
@@ -69,27 +69,21 @@ fn test_decode_reinit_response() {
 
 #[test]
 fn test_encode_stake_payload() {
-    let stake_id = 112345676_u64;
+    let stake_id = 5_u64;
     let reinit_payload = encode_stake_payload(&stake_id);
-
-    // 0000000006b2424c = 112345676_u64 (stake_id)
-    // 0x00 = ActionType::Stake
-    let expected = "0x0000000006b2424c00";
+    let expected = "0x0000000000000000000000000000000000000000000000000000000000000500";
 
     assert_eq!(binary_to_hex_string(reinit_payload), expected);
 }
 
 #[test]
 fn test_encode_unstake_payload() {
-    let lp_token_amount = Uint128::from(1000000000000000000_u128);
-    let unstake_id = 112345676_u64;
+    let lp_token_amount = Uint128::from(1000000_u128);
+    let unstake_id = 2_u64;
 
     let reinit_payload = encode_unstake_payload(&unstake_id, &lp_token_amount);
 
-    // 0x00000000000000000de0b6b3a7640000 = 1000000000000000000_u128
-    // 0x0000000006b2424c = 112345676_u64 (unstake_id)
-    // 0x01 = ActionType::Unstake
-    let expected = "0x00000000000000000de0b6b3a76400000000000006b2424c01";
+    let expected = "0x00000000000000000000000000000000000000000f4240000000000000000201";
 
     assert_eq!(binary_to_hex_string(reinit_payload), expected);
 }

--- a/cosmwasm/contracts/yield-ward/src/tests/reinit.rs
+++ b/cosmwasm/contracts/yield-ward/src/tests/reinit.rs
@@ -56,6 +56,7 @@ fn test_reinit() {
             user: ctx.unstake_user.clone(),
             lp_token_amount: unstake_details.lp_token_amount,
             action_stage: UnstakeActionStage::Executed,
+            token_amount: Some(unstake_details.unstake_token_amount)
         }
     );
 }

--- a/cosmwasm/contracts/yield-ward/src/tests/stake.rs
+++ b/cosmwasm/contracts/yield-ward/src/tests/stake.rs
@@ -33,6 +33,7 @@ fn test_init_stake_one_coin() {
             user: ctx.user.clone(),
             token_amount: stake_amount,
             action_stage: StakeActionStage::WaitingExecution,
+            lp_token_amount: None
         }
     );
 
@@ -92,6 +93,7 @@ fn test_stake_in_two_tx() {
             user: ctx.user.clone(),
             token_amount: stake_amount_1,
             action_stage: StakeActionStage::WaitingExecution,
+            lp_token_amount: None
         }
     );
 
@@ -102,6 +104,7 @@ fn test_stake_in_two_tx() {
             user: ctx.user,
             token_amount: stake_amount_2,
             action_stage: StakeActionStage::WaitingExecution,
+            lp_token_amount: None
         }
     );
 
@@ -130,6 +133,7 @@ fn test_stake_response_successful() {
         Status::Success,
         stake_id,
         reinit_unstake_id,
+        Uint128::zero(),
         lp_token_amount,
     );
 
@@ -161,6 +165,7 @@ fn test_stake_response_successful() {
             user: ctx.user,
             token_amount: stake_amount,
             action_stage: StakeActionStage::Executed,
+            lp_token_amount: Some(lp_token_amount)
         }
     );
 
@@ -190,6 +195,7 @@ fn test_stake_response_successful_with_reinit() {
         Status::Success,
         stake_id,
         unstake_details.unstake_id,
+        unstake_details.unstake_token_amount,
         lp_token_amount,
     );
 
@@ -221,6 +227,7 @@ fn test_stake_response_successful_with_reinit() {
             user: ctx.user.clone(),
             token_amount: stake_amount,
             action_stage: StakeActionStage::Executed,
+            lp_token_amount: Some(lp_token_amount)
         }
     );
 
@@ -247,6 +254,7 @@ fn test_stake_response_successful_with_reinit() {
             user: ctx.unstake_user.clone(),
             lp_token_amount: unstake_details.lp_token_amount,
             action_stage: UnstakeActionStage::Executed,
+            token_amount: Some(unstake_details.unstake_token_amount)
         }
     );
 
@@ -276,6 +284,7 @@ fn test_stake_response_fail() {
         Status::Fail,
         stake_id,
         reinit_unstake_id,
+        Uint128::zero(),
         lp_token_amount,
     );
 
@@ -307,6 +316,7 @@ fn test_stake_response_fail() {
             user: ctx.user.clone(),
             token_amount: stake_amount,
             action_stage: StakeActionStage::Failed,
+            lp_token_amount: None
         }
     );
 
@@ -336,6 +346,7 @@ fn test_stake_response_fail_with_reinit() {
         Status::Fail,
         stake_id,
         unstake_details.unstake_id,
+        unstake_details.unstake_token_amount,
         lp_token_amount,
     );
 
@@ -367,6 +378,7 @@ fn test_stake_response_fail_with_reinit() {
             user: ctx.user.clone(),
             token_amount: stake_amount,
             action_stage: StakeActionStage::Failed,
+            lp_token_amount: None
         }
     );
 
@@ -393,6 +405,7 @@ fn test_stake_response_fail_with_reinit() {
             user: ctx.unstake_user.clone(),
             lp_token_amount: unstake_details.lp_token_amount,
             action_stage: UnstakeActionStage::Executed,
+            token_amount: Some(lp_token_amount)
         }
     );
 

--- a/cosmwasm/contracts/yield-ward/src/tests/unstake.rs
+++ b/cosmwasm/contracts/yield-ward/src/tests/unstake.rs
@@ -34,6 +34,7 @@ fn stake_and_response(
         Status::Success,
         stake_id,
         reinit_unstake_id,
+        Uint128::zero(),
         lp_token_amount,
     );
 
@@ -53,6 +54,7 @@ fn stake_and_response(
             user: ctx.user.clone(),
             token_amount: stake_amount,
             action_stage: StakeActionStage::Executed,
+            lp_token_amount: Some(lp_token_amount)
         }
     );
 
@@ -104,7 +106,8 @@ fn test_init_unstake_one_coin() {
         UnstakeItem {
             user: ctx.user.clone(),
             lp_token_amount,
-            action_stage: UnstakeActionStage::WaitingRegistration
+            action_stage: UnstakeActionStage::WaitingRegistration,
+            token_amount: None
         }
     );
 
@@ -211,6 +214,7 @@ fn test_unstake_response_successful_instant_reinit() {
             user: ctx.user.clone(),
             action_stage: UnstakeActionStage::Executed,
             lp_token_amount,
+            token_amount: Some(unstake_amount)
         }
     );
 
@@ -273,6 +277,7 @@ fn test_unstake_response_successful_with_reinit() {
             user: ctx.user.clone(),
             action_stage: UnstakeActionStage::Executed,
             lp_token_amount,
+            token_amount: Some(unstake_amount)
         }
     );
 

--- a/cosmwasm/contracts/yield-ward/src/tests/utils/query.rs
+++ b/cosmwasm/contracts/yield-ward/src/tests/utils/query.rs
@@ -1,6 +1,6 @@
 use crate::msg::{
     GetContractConfigResponse, GetQueueParamsResponse, GetStakeItemResponse, GetStakeStatsResponse,
-    GetTokensConfigsResponse, GetUnstakeItemResponse, QueryMsg,
+    GetTokenDenomBySourceResponse, GetTokensConfigsResponse, GetUnstakeItemResponse, QueryMsg,
 };
 use crate::state::{ContractConfigState, QueueParams, StakeItem, StakeStatsItem, UnstakeItem};
 use crate::tests::utils::types::TestInfo;
@@ -118,6 +118,28 @@ pub fn get_all_tokens_configs(app: &BasicApp, ctx: &TestInfo) -> HashMap<TokenDe
 
     let configs: HashMap<_, _> = response.tokens.into_iter().collect();
     configs
+}
+
+pub fn get_token_denom_by_source(
+    app: &BasicApp,
+    ctx: &TestInfo,
+) -> HashMap<(String, String), TokenDenom> {
+    let response: GetTokenDenomBySourceResponse = app
+        .wrap()
+        .query_wasm_smart(
+            ctx.yield_ward_address.to_string(),
+            &QueryMsg::TokenDenomBySource {},
+        )
+        .unwrap();
+
+    let token_denom_by_source: HashMap<_, _> = response
+        .tokens_denoms
+        .into_iter()
+        .map(|(source_chain, source_address, token_denom)| {
+            ((source_chain, source_address), token_denom)
+        })
+        .collect();
+    token_denom_by_source
 }
 
 pub fn get_token_config(app: &BasicApp, ctx: &TestInfo, token_denom: &String) -> TokenConfig {

--- a/cosmwasm/tools/README.md
+++ b/cosmwasm/tools/README.md
@@ -6,16 +6,16 @@ Build:
 cargo build
 ```
 
-Encode stake message:
+Encode stake 15 USDC message:
 
 ```bash
-../target/debug/tools stake --token "weth"
+../target/debug/tools stake --token "usdc" --amount 15000000
 ```
 
-Encode unstake message:
+Encode unstake 0.001 LPETH message:
 
 ```bash
-../target/debug/tools unstake --token "weth"
+../target/debug/tools unstake --token "weth" --amount 1000000000000
 ```
 
 Encode stake response message:
@@ -26,7 +26,7 @@ Encode stake response message:
     --stake-id 1 \
     --is-success \
     --reinit-unstake-id 0 \
-    --lp-token-amount 101 \
+    --lp-token-amount 10000000000000000 \
     --return-amount 0
 ```
 

--- a/cosmwasm/tools/src/common.rs
+++ b/cosmwasm/tools/src/common.rs
@@ -10,6 +10,7 @@ pub struct TokenDetails {
     pub _token: Token,
     pub _deposit_token_address: String,
     pub _lp_token_address: String,
+    pub _decimals: u8,
     pub deposit_token_denom: String,
     pub chain: String,
     pub yield_ward_address: String,
@@ -25,6 +26,7 @@ pub fn get_token_details(token: &String) -> TokenDetails {
         "weth" => TokenDetails {
             _token: Token::WETH,
             deposit_token_denom: "demo_weth".to_string(),
+            _decimals: 18,
             _deposit_token_address:
                 "warden1dk9c86h7gmvuaq89cv72cjhq4c97r2wgl5gyfruv6shquwspalgqr09xey".to_string(),
             _lp_token_address: "warden12nnqks893jx3pz34yj4r4uhlvvgw5e6zjkjwxx03pxtd8y89faqseepx4j"
@@ -36,6 +38,7 @@ pub fn get_token_details(token: &String) -> TokenDetails {
         "usdt" => TokenDetails {
             _token: Token::USDT,
             deposit_token_denom: "demo_usdt".to_string(),
+            _decimals: 6,
             _deposit_token_address:
                 "warden1xqkp8x4gqwjnhemtemc5dqhwll6w6rrgpywvhka7sh8vz8swul9ss7ztuk".to_string(),
             _lp_token_address: "warden1uyvxsvmjh8j4vnekgdl3rc36pjepaqdqw5999gmkfk05zrs3y03sd6g5wz"
@@ -47,6 +50,7 @@ pub fn get_token_details(token: &String) -> TokenDetails {
         "usdc" => TokenDetails {
             _token: Token::USDC,
             deposit_token_denom: "demo_usdc".to_string(),
+            _decimals: 6,
             _deposit_token_address:
                 "warden1euqmngymytlt8j707spv9hn6ajzy92ndfjk47pnlu9uzmfuyplhsyeh0vc".to_string(),
             _lp_token_address: "warden1qex8hj0ux0vlrzvvnydztlhlrz4whfreahvf49lgjd6zthaf8zsqlq5x4u"


### PR DESCRIPTION
Fixes for:
- payload padding to `u256`
- reinit processing while stake successful response
- update `TOKEN_DENOM_BY_SOURCE` storage while token config update

Also:
- update tests
- add `lp_token_amount` to `StakeItem` storage
- add `token_amount` to `UnstakeItem`
- update response events